### PR TITLE
Making `IStateObserver.Value` not nullable. It still may be nullable, adding `?` in generic argument

### DIFF
--- a/BlazingState/IStateObserver.cs
+++ b/BlazingState/IStateObserver.cs
@@ -14,7 +14,7 @@ namespace BlazingState
         /// Sets/gets the value of this observer.
         /// Doesn't wait for all components to finish rerendering.
         /// </summary>
-        public T? Value { get; set; }
+        public T Value { get; set; }
 
         /// <summary>
         /// Sets the value of this observer with optionally specifying from which instance the change came.
@@ -22,7 +22,7 @@ namespace BlazingState
         /// </summary>
         /// <param name="newValue"></param>
         /// <param name="instance"></param>
-        public void SetValue(T? newValue, object? instance = null);
+        public void SetValue(T newValue, object? instance = null);
 
         /// <summary>
         /// Sets the value of this observer with optionally specifying from which instance the change came.
@@ -31,7 +31,7 @@ namespace BlazingState
         /// <param name="newValue"></param>
         /// <param name="instance"></param>
         /// <returns></returns>
-        public Task SetValueAsync(T? newValue, object? instance = null);
+        public Task SetValueAsync(T newValue, object? instance = null);
 
         /// <summary>
         /// Notifies all components that the state changed.

--- a/BlazingState/StateObserver.cs
+++ b/BlazingState/StateObserver.cs
@@ -16,9 +16,9 @@ namespace BlazingState
         private readonly EqualityComparer<T> equalityComparer;
         private readonly IAutoStateManager? autoStateManager;
 
-        private T? currentValue;
+        private T currentValue = default!;
 
-        public T? Value
+        public T Value
         {
             get => currentValue;
             set
@@ -55,7 +55,7 @@ namespace BlazingState
             await NotifyStateChangedAsync(instance);
         }
 
-        private bool SetValueInternal(T? newValue)
+        private bool SetValueInternal(T newValue)
         {
             if (!equalityComparer.Equals(currentValue, Value))
                 return false;
@@ -64,13 +64,13 @@ namespace BlazingState
             return true;
         }
 
-        public void SetValue(T? newValue, object? instance = null)
+        public void SetValue(T newValue, object? instance = null)
         {
             if (SetValueInternal(newValue))
                 NotifyStateChangedInternalAsync(instance);
         }
 
-        public Task SetValueAsync(T? newValue, object? instance = null)
+        public Task SetValueAsync(T newValue, object? instance = null)
         {
             if (SetValueInternal(newValue))
                 return NotifyStateChangedAsync(instance);

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public class MyData
 // Register BlazingState
 builder.Services.AddBlazingState()
     // Registers a state observer of this type with no initial value
-    .AddStateObserver<MyData>();
+    .AddStateObserver<MyData?>();
     // You can also initialize MyData with an initial value
     .AddStateObserver<MyData>(new MyData());
     // And even with an implementation factory

--- a/Samples/BlazingState.Sample/Data/Account.cs
+++ b/Samples/BlazingState.Sample/Data/Account.cs
@@ -2,6 +2,6 @@
 {
     public class Account
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 }

--- a/Samples/BlazingState.Sample/Data/CompanyInfo.cs
+++ b/Samples/BlazingState.Sample/Data/CompanyInfo.cs
@@ -2,6 +2,6 @@
 {
     public class CompanyInfo
     {
-        public string Name { get; set; }
+        public required string Name { get; set; }
     }
 }

--- a/Samples/BlazingState.Sample/Pages/AutoStateDemoAll.razor
+++ b/Samples/BlazingState.Sample/Pages/AutoStateDemoAll.razor
@@ -14,8 +14,8 @@
 @*@inject IStateObserver<Account> Account;*@
 @attribute [AutoState]
 @code {
-	[Inject] protected IStateObserver<CompanyInfo> CompanyInfo { get; set; } = null!;
-	[Inject] protected IStateObserver<Account> Account { get; set; } = null!;
+	[Inject] protected IStateObserver<CompanyInfo> CompanyInfo { get; set; } = null!; // not nullable
+	[Inject] protected IStateObserver<Account?> Account { get; set; } = null!;
 
 	protected new void StateHasChanged()
 	{

--- a/Samples/BlazingState.Sample/Pages/AutoStateDemoSpecific.razor
+++ b/Samples/BlazingState.Sample/Pages/AutoStateDemoSpecific.razor
@@ -4,7 +4,7 @@
 
 <h1>AutoStateDemoSpecific</h1>
 
-<p>Company Name: @CompanyInfo.Value?.Name</p>
+<p>Company Name: @CompanyInfo.Value.Name</p>
 <ManageCompanyInfo />
 
 <hr />
@@ -14,8 +14,8 @@
 @attribute [AutoState(typeof(CompanyInfo))]
 @code {
 	// AutoState is only managed for this StateObserver
-	[Inject] protected IStateObserver<CompanyInfo> CompanyInfo { get; set; } = null!;
-	[Inject] protected IStateObserver<Account> Account { get; set; } = null!;
+	[Inject] protected IStateObserver<CompanyInfo> CompanyInfo { get; set; } = null!; // Not nullable state
+	[Inject] protected IStateObserver<Account?> Account { get; set; } = null!;
 
 	protected override void OnParametersSet()
 	{

--- a/Samples/BlazingState.Sample/Pages/Counter.razor
+++ b/Samples/BlazingState.Sample/Pages/Counter.razor
@@ -4,17 +4,31 @@
 
 <h1>Counter</h1>
 
-<p role="status">Current count: @currentCount</p>
+<p role="status">Current count: @_localState.Value</p>
 
+<button class="btn btn-primary" @onclick="IncrementCountNotAutoState">Click me async afrer 1500ms</button>
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
 <ManageCompanyInfo />
 
 @code {
-    private int currentCount = 0;
+
+
+    private IStateObserver<int> _localState = new StateObserver<int>(0);
+
+    protected override void OnInitialized()
+    {
+        _localState.Register(this, StateHasChanged);
+    }
+
+    private async void IncrementCountNotAutoState()
+    {
+        await Task.Delay(1500);
+        _localState.SetValue(_localState.Value + 1);
+    }
 
     private void IncrementCount()
     {
-        currentCount++;
+        _localState.SetValue(_localState.Value + 1,this);
     }
 }

--- a/Samples/BlazingState.Sample/Pages/Counter.razor
+++ b/Samples/BlazingState.Sample/Pages/Counter.razor
@@ -6,7 +6,7 @@
 
 <p role="status">Current count: @_localState.Value</p>
 
-<button class="btn btn-primary" @onclick="IncrementCountNotAutoState">Click me async afrer 1500ms</button>
+<button class="btn btn-primary" @onclick="IncrementCountNotAutoState">Click me (invoke after 1500ms)</button>
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
 <ManageCompanyInfo />

--- a/Samples/BlazingState.Sample/Pages/Index.razor
+++ b/Samples/BlazingState.Sample/Pages/Index.razor
@@ -6,7 +6,7 @@
 
 Welcome to your new app.
 
-<p>Company Name: @CompanyInfo.Value?.Name</p>
+<p>Company Name: @CompanyInfo.Value.Name</p>
 
 <div class="row">
 	<div class="col-auto">
@@ -33,7 +33,7 @@ Welcome to your new app.
 
 @code {
 	[Inject] protected IStateObserver<CompanyInfo> CompanyInfo { get; set; } = null!;
-	[Inject] protected IStateObserver<Account> Account { get; set; } = null!;
+	[Inject] protected IStateObserver<Account?> Account { get; set; } = null!;
 
 	private int cachedEvents = 0; 
 	private string newCompanyName = "";
@@ -56,7 +56,7 @@ Welcome to your new app.
 		base.StateHasChanged();
 	}
 
-	private async Task Save()
+	private void Save()
 	{
 		CompanyInfo.Value = new CompanyInfo { Name = newCompanyName };
 	}

--- a/Samples/BlazingState.Sample/Program.cs
+++ b/Samples/BlazingState.Sample/Program.cs
@@ -14,7 +14,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddBlazingState()
     .AddAutoState()
     .AddStateObserver<CompanyInfo>(new CompanyInfo { Name = "InitialName" })
-    .AddStateObserver<Account>();
+    .AddStateObserver<Account?>();
 
 
 // Build

--- a/Samples/BlazingState.Sample/Shared/NavMenu.razor
+++ b/Samples/BlazingState.Sample/Shared/NavMenu.razor
@@ -16,7 +16,7 @@
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="counter">
-                <span class="oi oi-plus" aria-hidden="true"></span> Counter
+                <span class="oi oi-plus" aria-hidden="true"></span> Counter State demo
             </NavLink>
         </div>
         <div class="nav-item px-3">


### PR DESCRIPTION
to #2 issue
Nullable state observer:
```cs

class MyState 
{
   public string Name { get; set; }
}
IStateObserver<MyState> state = new StateObserver<MyState>(new MyState()); // not nullable
IStateObserver<MyState?> state = new StateObserver<MyState?>(); // may be nullable

IStateObserver<int?> intstate = new StateObserver<int?>(); //nullable
IStateObserver<int> intstate = new StateObserver<int>(); //not nullable state with value type
```
